### PR TITLE
Fixed warning issues by attr method

### DIFF
--- a/lib/dbi/handles.rb
+++ b/lib/dbi/handles.rb
@@ -9,7 +9,7 @@ module DBI
     class Handle
         attr_reader :trace_mode, :trace_output
         attr_reader :handle 
-        attr :convert_types, true
+        attr_accessor :convert_types
 
         def initialize(handle, convert_types=true)
             @handle = handle


### PR DESCRIPTION
The attr method that accepts a boolean is obsolete, and prints an annoying warning. I replaced the method call with the equivalent attr_accessor call.
