### PR TITLE
Update row.rb to allow ruby versions 2+ to run

### DIFF
--- a/lib/dbi/row.rb
+++ b/lib/dbi/row.rb
@@ -209,7 +209,7 @@ module DBI
         end
 
 
-        if RUBY_VERSION =~ /^1\.9/
+        if RUBY_VERSION =~ /^1\.9/ || RUBY_VERSION =~ /^2/
             def __getobj__
                 @arr
             end


### PR DESCRIPTION
Without this line, you get 

```
usr/lib/ruby/2.1.0/delegate.rb:392:in __getobj__': not delegated (ArgumentError)
from /usr/lib/ruby/2.1.0/delegate.rb:341:inblock in delegating_block
```'